### PR TITLE
Check that the TextEditor is valid

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -18,7 +18,7 @@ export default {
     activate: () => {
         this.rIndent = new RIndent();
         this.subscriptions = new CompositeDisposable();
-        this.subscriptions.add(atom.commands.add("atom-text-editor",
+        this.subscriptions.add(atom.commands.add("atom-text-editor:not(.mini)",
             { "editor:newline": () => this.rIndent.properlyIndent() }));
     },
 };

--- a/lib/r-indent.js
+++ b/lib/r-indent.js
@@ -2,6 +2,9 @@
 export default class RIndent {
     properlyIndent() {
         this.editor = atom.workspace.getActiveTextEditor();
+        if (!atom.workspace.isTextEditor(this.editor)) {
+            return;
+        }
         const language = this.editor.getGrammar().scopeName.substring(0, 13);
 
         // Make sure this is a Python file


### PR DESCRIPTION
Check that the `TextEditor` returned from `atom.workspace.getActiveTextEditor` is valid before using it. Also stops registering the callback for `.mini` `TextEditor`s.

Fixes #8.