### PR TITLE
Moved definition of >= and <= up in order to properly identify them.

### DIFF
--- a/grammars/r.cson
+++ b/grammars/r.cson
@@ -126,6 +126,10 @@
         'match': '\\.[0-9]+(?:(e|E)(\\+|-)?[0-9]+)?\\b'
         'name': 'constant.numeric.float.decimal.r'
       }
+      {
+        'match': '(<=|>=)'
+        'name': 'keyword.operator.comparison.r'
+      }
     ]
   }
   'general-variables': {


### PR DESCRIPTION
I have moved up the definition of the two comparison operators (>= and <=) so that now they are correctly recognised as individual operators instead of the composition of comparison and assignment.  This is the simplest fix to the problem but probably not the most elegant.
